### PR TITLE
fix: clear attachments in PromptInput after message has been submitted

### DIFF
--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -410,6 +410,7 @@ export const PromptInput = ({
     }));
 
     onSubmit({ text: event.currentTarget.message.value, files }, event);
+    clear();
   };
 
   const ctx = useMemo<AttachmentsContext>(


### PR DESCRIPTION
I've noticed that attachments are not cleared automatically after a message has been submitted when using the `PromptInput` component. This PR fixes that - as there are currently no test cases within the repo, I didn't add any for this PR. However, that could be a nice addition in a separate one :) 